### PR TITLE
"NLTK download SSL: Certificate verify failed" fixed

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/2023_NLP.iml
+++ b/.idea/2023_NLP.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.9 (2023_NLP)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,36 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="tensorflow" />
+            <item index="1" class="java.lang.String" itemvalue="keras" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E302" />
+          <option value="E305" />
+          <option value="E231" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="float.__xor__" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (2023_NLP)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/2023_NLP.iml" filepath="$PROJECT_DIR$/.idea/2023_NLP.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/23_March-16_nltk_practice_1.ipynb
+++ b/23_March-16_nltk_practice_1.ipynb
@@ -78,15 +78,39 @@
     },
     "outputId": "50e190ec-3e1f-4b37-aeff-6f22901d6aa7"
    },
-   "execution_count": null,
+   "execution_count": 2,
    "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "showing info https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/index.xml\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#A download utility to get a lot of data!\n",
+    "import ssl\n",
+    "try:\n",
+    "    _create_unverified_https_context = ssl._create_unverified_context\n",
+    "except AttributeError:\n",
+    "    pass\n",
+    "else:\n",
+    "    ssl._create_default_https_context = _create_unverified_https_context\n",
+    "\n",
     "nltk.download()"
    ],
    "metadata": {
@@ -115,8 +139,20 @@
     "id": "gSZvoinfDHRz",
     "outputId": "a59638b7-5e45-4073-c963-a9ba4285d726"
    },
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 1,
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'nltk' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mNameError\u001B[0m                                 Traceback (most recent call last)",
+      "Cell \u001B[0;32mIn[1], line 6\u001B[0m\n\u001B[1;32m      4\u001B[0m \u001B[38;5;66;03m## Download a specific dataset\u001B[39;00m\n\u001B[1;32m      5\u001B[0m \u001B[38;5;28;01mtry\u001B[39;00m:\n\u001B[0;32m----> 6\u001B[0m     \u001B[43mnltk\u001B[49m\u001B[38;5;241m.\u001B[39mdata\u001B[38;5;241m.\u001B[39mfind(\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mbrown\u001B[39m\u001B[38;5;124m'\u001B[39m)\n\u001B[1;32m      7\u001B[0m \u001B[38;5;28;01mexcept\u001B[39;00m \u001B[38;5;167;01mLookupError\u001B[39;00m:\n\u001B[1;32m      8\u001B[0m     nltk\u001B[38;5;241m.\u001B[39mdownload(\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mbrown\u001B[39m\u001B[38;5;124m'\u001B[39m)\n",
+      "\u001B[0;31mNameError\u001B[0m: name 'nltk' is not defined"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
"NLTK download SSL: Certificate verify failed" error was thrown in the previous commit when `nltk.download()`. This commit solves the problem. This snippet might be required when downloading `punkt`, `wordnet` and `stopwords` as well.
Reference: https://github.com/gunthercox/ChatterBot/issues/930#issuecomment-322111087